### PR TITLE
Fix consul lock acquisition issue

### DIFF
--- a/src/consul.rs
+++ b/src/consul.rs
@@ -87,8 +87,6 @@ struct ConsulLock {
 struct ConsulKVResponse {
     #[serde(rename = "Value")]
     value: Option<String>,
-    #[serde(rename = "Key")]
-    key: String,
     #[serde(rename = "Session")]
     session: Option<String>,
 }
@@ -203,8 +201,8 @@ impl ConsulClient {
 
             let kvs = response.json::<Vec<ConsulKVResponse>>().await?;
 
-            for kv in kvs {
-                if kv.key == CONSUL_STORE_KEY && kv.session.is_none() {
+            if let Some(kv) = kvs.first() {
+                if kv.session.is_none() {
                     info!("Consul lock is now free");
                     return Ok(());
                 }

--- a/src/consul.rs
+++ b/src/consul.rs
@@ -208,6 +208,7 @@ impl ConsulClient {
                     return Ok(());
                 }
             }
+            warn!("Consul lock is still held, waiting...");
         }
     }
 

--- a/src/consul.rs
+++ b/src/consul.rs
@@ -191,7 +191,8 @@ impl ConsulClient {
             if let Some(index) = consul_index.take() {
                 req = req.query(&[("index", &index)]);
             }
-            let response = req.send().await?;
+
+            let response = req.timeout(Duration::from_secs(30)).send().await?;
 
             consul_index = response
                 .headers()


### PR DESCRIPTION
Fixes #19 
The root cause of the lock acquisition failure wasn't the request hanging, but incorrect key comparison when examining the response (using CONSUL_STORE_KEY instead of CONSUL_STORE_KEY + "lock"). The check for key is not necessary, so it has been removed.

Added a 30-second timeout as a safety measure to prevent indefinite hanging in case of network issues. 

Also enhanced logging to provide better visibility for troubleshooting similar issues in the future.
